### PR TITLE
Add management server

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Metrics/BlockLength:
     - 'spec/bm/instrumentations/**/*'
     - 'spec/sequel/extensions/**'
     - 'spec/roda/plugins/**'
+    - 'spec/integrations/**/*'
     - 'bm-instrumentations.gemspec'
 
 RSpec/MultipleExpectations:

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'simplecov', '= 0.21.1'
 
 gem 'aws-sdk-s3', '~> 1.94' # aws
 gem 'mysql2', '~> 0.5' # sequel
+gem 'puma', '~> 5.3' # management
 gem 'rack', '~> 2.2' # rack
 gem 'rack-test', '~> 1.1' # rack
 gem 'roda', '~> 3.43' # roda

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+Rake.add_rakelib 'lib/tasks/**'
 
 RuboCop::RakeTask.new :rubocop do |t|
   formatters = %w[--format progress --format RuboCop::Formatter::CheckstyleFormatter]
@@ -13,7 +12,8 @@ RuboCop::RakeTask.new :rubocop do |t|
   t.options = requires + formatters + out
 end
 
-task default: :spec
+desc 'Run RSpec code examples'
+task default: %i[spec:unit]
 
-desc 'Run rubocop and when tests'
-task ci: %i[rubocop spec]
+desc 'Run rubocop, then tests, then merge coverage reports'
+task ci: %i[rubocop spec:unit spec:integrations simplecov:merge]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       - mysql-data:/var/lib/mysql:delegated
 
   minio:
-    image: "bitnami/minio:latest"
-    command: "server /var/lib/minio"
+    image: "bitnami/minio"
     environment:
       MINIO_ACCESS_KEY: "AccessKey"
       MINIO_SECRET_KEY: "SecretKey"

--- a/lib/bm/instrumentations.rb
+++ b/lib/bm/instrumentations.rb
@@ -23,5 +23,9 @@ module BM
     module Sequel
       autoload :MetricsCollection, 'bm/instrumentations/sequel/metrics_collection'
     end
+
+    module Management
+      autoload :Server,            'bm/instrumentations/management/server'
+    end
   end
 end

--- a/lib/bm/instrumentations/management/server.rb
+++ b/lib/bm/instrumentations/management/server.rb
@@ -4,6 +4,7 @@ require 'rack'
 require 'logger'
 require 'puma'
 require 'prometheus/client'
+require 'prometheus/client/formats/text'
 
 module BM
   module Instrumentations

--- a/lib/bm/instrumentations/management/server.rb
+++ b/lib/bm/instrumentations/management/server.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'rack'
+require 'logger'
+require 'puma'
+require 'prometheus/client'
+require 'prometheus/middleware/exporter'
+
+module BM
+  module Instrumentations
+    module Management
+      # @attr [String] host
+      # @attr [Integer] port
+      # @attr [Logger] logger
+      # @attr [Prometheus::Client::Registry] registry
+      class Server
+        attr_reader :host, :port, :logger, :registry
+
+        BACKLOG = 3
+        THREADS = 1
+        THREAD_NAME = 'management-server'
+        SERVES = %w[/ping /metrics /gc-stats /threads].freeze
+
+        # @param host [String] is a hostname to listen on
+        # @param port [Integer] is a port to listen on
+        # @param logger [Logger]
+        # @param registry [Prometheus::Client::Registry]
+        #
+        # @api private
+        def initialize(port:, host:, logger:, registry:)
+          @host = host
+          @port = port
+          @logger = logger
+          @registry = registry
+        end
+        private_class_method :new
+
+        # Creates a management server backed by {Puma::Server} then bind and
+        # listen to socket
+        #
+        # @param host [String, nil] is a hostname to listen on
+        # @param port [Integer] is a port to listen on
+        # @param logger [Logger, nil]
+        # @param registry [Prometheus::Client::Registry, nil]
+        #
+        # @return [Running]
+        def self.run(port:, host: nil, logger: nil, registry: nil)
+          new(
+            port: port,
+            host: host || '127.0.0.1',
+            logger: logger || ::Logger.new($stdout, progname: Server.class.name),
+            registry: registry || ::Prometheus::Client.registry
+          ).run
+        end
+
+        # Creates a management server backed by {Puma::Server} then bind and
+        # listen to socket
+        #
+        # @return [Running]
+        # @api private
+        def run
+          server = ::Puma::Server.new(rack_app, ::Puma::Events.stdio, puma_options)
+          server.auto_trim_time = nil # disable trimming thread
+          server.reaping_time = nil # disable reaping thread
+          server.add_tcp_listener(host, port, _optimize_for_latency = true, _backlog = BACKLOG)
+
+          Running.new(server, logger).tap { notify_started }
+        end
+
+        private
+
+        # Writes log messages about just launched management server instance
+        def notify_started
+          logger.info(
+            "Management server listen to http://#{host}:#{port}" \
+            "[Puma/#{Puma::Server::VERSION}," \
+            " threads:#{THREADS}," \
+            " backlog:#{BACKLOG}]"
+          )
+
+          logger.info("Management serves #{SERVES.join(' ')}")
+        end
+
+        # @return [Hash<Symbol, Any>]
+        def puma_options
+          {
+            min_threads: THREADS,  # uses a fixed sized thread pool
+            max_threads: THREADS,  #
+            queue_requests: false, # disable incoming requests buffering
+            shutdown_debug: false  # for debugging reasons, may be enabled for testing
+          }.freeze
+        end
+
+        # Builds a Rack application that serves requests to the management server
+        #
+        # @return [#call] a frozen rack application
+        def rack_app
+          ::Rack::ShowExceptions.new(
+            ::Prometheus::Middleware::Exporter.new(ServeEndpoints.new, registry: registry)
+          ).tap(&:freeze)
+        end
+
+        # Handles a running server instance
+        #
+        # @attr server [Puma::Server]
+        # @attr logger [Logger]
+        class Running
+          attr_reader :server, :logger
+
+          # @param server [Puma::Server]
+          # @param logger [Logger]
+          def initialize(server, logger)
+            @server = server
+            @logger = logger
+            server.run(_background = true, thread_name: THREAD_NAME)
+          end
+
+          # Shutdowns and wait until the server finishes
+          #
+          # @return [nil]
+          def shutdown
+            server&.stop(_sync = true)
+            @server = nil
+            logger.info('Management server done')
+          end
+        end
+
+        # Handles management requests such as /ping or /threads
+        #
+        # @api private
+        class ServeEndpoints
+          JSON_TEXT = { 'Content-Type' => 'application/json' }.freeze
+          PLAIN_TEXT = { 'Content-Type' => 'text/plain' }.freeze
+          PONG = [200, PLAIN_TEXT, ['pong']].freeze
+          NOT_FOUND = [404, PLAIN_TEXT, ['not found']].freeze
+
+          # @param env [Hash<String, Any>]
+          # @return [(Integer, Hash<String, String>, Array<String>)]
+          def call(env) # rubocop:disable Metrics/MethodLength
+            return NOT_FOUND if env[::Rack::REQUEST_METHOD] != ::Rack::GET
+
+            case env[::Rack::PATH_INFO]
+            when '/ping'
+              PONG
+            when '/gc-stats'
+              to_json(GC.stat)
+            when '/threads'
+              to_json(threads_list)
+            else
+              NOT_FOUND
+            end
+          end
+
+          private
+
+          # Returns a list of thread name and its backlog
+          #
+          # @return [Array<Hash<Symbol, String>>]
+          def threads_list
+            Thread.list.map { { name: _1.name, backtrace: _1.backtrace } }
+          end
+
+          # Converts value to JSON using Puma's generator
+          #
+          # @param value [Hash, Array]
+          # @return [(Integer, Hash<String, String>, Array<String>)]
+          def to_json(value)
+            body = ::Puma::JSON.generate(value)
+            [200, JSON_TEXT, [body]]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bm/instrumentations/management/server.rb
+++ b/lib/bm/instrumentations/management/server.rb
@@ -13,8 +13,9 @@ module BM
       # @attr [Integer] port
       # @attr [Logger] logger
       # @attr [Prometheus::Client::Registry] registry
+      # @attr [Puma::Events] events
       class Server
-        attr_reader :host, :port, :logger, :registry
+        attr_reader :host, :port, :logger, :registry, :events
 
         BACKLOG = 3
         THREADS = 1

--- a/lib/puma/plugin/management_server.rb
+++ b/lib/puma/plugin/management_server.rb
@@ -4,26 +4,47 @@ require 'puma/dsl'
 require 'puma/plugin'
 require 'bm/instrumentations'
 
-Puma::DSL.include(Module.new do
-  def management_server(port:, host: nil, logger: nil)
-    @options[:management_server_port] = port
-    @options[:management_server_host] = host if host
-    @options[:management_server_logger] = logger if logger
+module BM
+  module Instrumentations
+    module Management
+      # The {Puma::DSL} extension for configuring a management server
+      #
+      # @example config/puma.rb
+      #   plugin(:management_server)
+      #   management_server(port: 9000, host: '127.0.0.1', logger: SemanticLogger::Loggable['Management::Server'])
+      module PumaDSL
+        # Override the default {Server} configuration
+        #
+        # @param port [Integer] override a default port number that a server will listen to (default: 9990)
+        # @param host [String, nil] override a default bind address that a server uses for
+        #   listening (default: '0.0.0.0')
+        # @param logger [Logger, nil] override a default logger (default: `Logger.new($stdout)`)
+        # @param registry [Prometheus::Client::Registry] override a default registry
+        def management_server(port: nil, host: nil, logger: nil, registry: nil)
+          @options[:management_server_port] = port if port
+          @options[:management_server_host] = host if host
+          @options[:management_server_logger] = logger if logger
+          @options[:management_server_registry] = registry if registry
+        end
+      end
+    end
   end
-end)
+end
+
+Puma::DSL.include BM::Instrumentations::Management::PumaDSL
 
 Puma::Plugin.create do
   # @param launcher [Puma::Launcher]
   def start(launcher)
-    port = launcher.options[:management_server_port] || 9000
     host = launcher.options[:management_server_host]
+    port = launcher.options[:management_server_port]
     logger = launcher.options[:management_server_logger]
+    registry = launcher.options[:management_server_registry]
 
     # @type [Puma::Events]
     events = launcher.events
-
     events.on_booted do
-      server = BM::Instrumentations::Management::Server.run(port: port, host: host, logger: logger)
+      server = BM::Instrumentations::Management::Server.run(port: port, host: host, logger: logger, registry: registry)
       events.on_stopped { server.shutdown }
     end
   end

--- a/lib/puma/plugin/management_server.rb
+++ b/lib/puma/plugin/management_server.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'puma/dsl'
+require 'puma/plugin'
+require 'bm/instrumentations'
+
+Puma::DSL.include(Module.new do
+  def management_server(port:, host: nil, logger: nil)
+    @options[:management_server_port] = port
+    @options[:management_server_host] = host if host
+    @options[:management_server_logger] = logger if logger
+  end
+end)
+
+Puma::Plugin.create do
+  # @param launcher [Puma::Launcher]
+  def start(launcher)
+    port = launcher.options[:management_server_port] || 9000
+    host = launcher.options[:management_server_host]
+    logger = launcher.options[:management_server_logger]
+
+    # @type [Puma::Events]
+    events = launcher.events
+
+    events.on_booted do
+      server = BM::Instrumentations::Management::Server.run(port: port, host: host, logger: logger)
+      events.on_stopped { server.shutdown }
+    end
+  end
+end

--- a/lib/roda/plugins/prometheus_instrumentation.rb
+++ b/lib/roda/plugins/prometheus_instrumentation.rb
@@ -6,11 +6,7 @@ require 'prometheus/middleware/exporter'
 class Roda
   # :nodoc:
   module RodaPlugins
-    # The `prometheus_instrumentation` plugin adds the Prometheus exporter and the collector to the application.
-    #
-    # This is a meta plugins which does nothing except adding (and optionally configuring) two middlewares:
-    # * [BM::Instrumentations::Rack::Collector]
-    # * [Prometheus::Middleware::Exporter]
+    # The `prometheus_instrumentation` plugin just add {Rack::Collector} to the current Roda application.
     #
     # @example Apply plugin
     #   class API < Roda
@@ -25,9 +21,8 @@ class Roda
       # @param app [Any]
       # @param registry [Prometheus::Client::Registry, nil] override the default registry
       # @param exclude_path [String, Array<String>, nil] override the default (/metrics) exclude path
-      def self.configure(app, registry: nil, exclude_path: %w[/metrics])
+      def self.configure(app, registry: nil, exclude_path: nil)
         app.use ::BM::Instrumentations::Rack::Collector, registry: registry, exclude_path: exclude_path
-        app.use ::Prometheus::Middleware::Exporter, registry: registry
       end
     end
 

--- a/lib/tasks/simplecov.rake
+++ b/lib/tasks/simplecov.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :simplecov do
+  desc 'Merge Coverage Reports'
+  task :merge do
+    next if ENV.fetch('SIMPLECOV', '').empty?
+
+    files = Dir['coverage/*/.resultset.json']
+    next if files.empty?
+
+    require 'simplecov'
+    require 'simplecov_json_formatter'
+
+    SimpleCov.collate files do
+      formatter SimpleCov::Formatter::MultiFormatter.new(
+        [SimpleCov::Formatter::JSONFormatter, SimpleCov::Formatter::HTMLFormatter]
+      )
+    end
+  end
+end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rspec/core/rake_task'
+
+namespace :spec do
+  RSpec::Core::RakeTask.new(:unit)
+
+  desc 'Run Integrations Specs'
+  task :integrations do
+    Dir['spec/integrations/**/*_spec.rb'].each_with_index do |file, idx|
+      env = ["SIMPLECOV=#{ENV['SIMPLECOV']}"]
+      env << ["SIMPLECOV_COMMAND_NAME=integration-#{idx}"]
+      env << ['INTEGRATION_SPECS=1']
+      sh "#{env.join(' ')} bundle exec rspec #{file}"
+    end
+  end
+end

--- a/spec/bm/instrumentations/aws/collector_spec.rb
+++ b/spec/bm/instrumentations/aws/collector_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe BM::Instrumentations::Aws::Collector do
 
   describe 'collect metrics', 'when an exception has raised' do
     let(:labels) { { status: 500, service: 'S3', api: 'ListBuckets' } }
-    let(:s3_host) { non_listening_endpoint }
+    let(:s3_host) { "127.0.0.1:#{non_listening_port}" }
 
     before do
       expect { s3_client.list_buckets }.to raise_error(Seahorse::Client::NetworkingError)
@@ -76,14 +76,5 @@ RSpec.describe BM::Instrumentations::Aws::Collector do
     it 'increments a :aws_sdk_client_retries_total' do
       expect(counter_value(:aws_sdk_client_retries_total, service: 'S3', api: 'ListBuckets')).to eq(3.0)
     end
-  end
-
-  # @return [String]
-  def non_listening_endpoint
-    require 'socket'
-    server = TCPServer.new('127.0.0.1', 0)
-    "#{server.addr[2]}:#{server.addr[1]}"
-  ensure
-    server&.close
   end
 end

--- a/spec/bm/instrumentations/management/server_spec.rb
+++ b/spec/bm/instrumentations/management/server_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe BM::Instrumentations::Management::Server, net_http: true do
       expect(response).to be_ok.have_content_type('text/plain; version=0.0.4')
       expect(response).to have_body("# TYPE tests_total counter\n# HELP tests_total Testing\ntests_total 1.0\n")
     end
+
+    it_behaves_like 'when non GET request'
   end
 
   describe 'a /gc-stats endpoint' do

--- a/spec/bm/instrumentations/management/server_spec.rb
+++ b/spec/bm/instrumentations/management/server_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'bm/instrumentations'
+
+RSpec.describe BM::Instrumentations::Management::Server do
+  subject(:server_run) { described_class.run(host: host, port: 0, registry: registry) }
+
+  let(:host) { '127.0.0.1' }
+  let(:registry) { Prometheus::Client::Registry.new }
+  let(:uri) { URI("http://#{host}:#{server_run.port}#{endpoint}") }
+  let(:response) { Net::HTTP.get_response(uri) }
+
+  before { server_run }
+
+  after { server_run.shutdown }
+
+  shared_examples 'when non GET request' do
+    subject(:response) { Net::HTTP.post(uri, '') }
+
+    it 'responds with 404' do
+      expect(response).to be_not_found.have_content_type('text/plain')
+      expect(response).to have_body('not found')
+    end
+  end
+
+  describe 'a /ping endpoint' do
+    let(:endpoint) { '/ping' }
+
+    it 'responds successfully' do
+      expect(response).to be_ok.have_content_type('text/plain')
+      expect(response).to have_body('pong')
+    end
+
+    it_behaves_like 'when non GET request'
+  end
+
+  describe 'a /metrics endpoint' do
+    let(:endpoint) { '/metrics' }
+
+    before do
+      counter = registry.counter(:tests_total, docstring: 'Testing')
+      counter.increment
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_ok.have_content_type('text/plain; version=0.0.4')
+      expect(response).to have_body("# TYPE tests_total counter\n# HELP tests_total Testing\ntests_total 1.0\n")
+    end
+  end
+
+  describe 'a /gc-stats endpoint' do
+    let(:endpoint) { '/gc-stats' }
+
+    it 'responds successfully' do
+      expect(response).to be_ok.have_content_type('application/json')
+      expect(response).to have_body('"heap_allocated_pages":')
+    end
+
+    it_behaves_like 'when non GET request'
+  end
+
+  describe 'a /threads endpoint' do
+    let(:endpoint) { '/threads' }
+
+    it 'responds successfully' do
+      expect(response).to be_ok.have_content_type('application/json')
+      expect(response).to have_body(__FILE__)
+      expect(response).to have_body('"name":"puma threadpool 001"')
+      expect(response).to have_body('"name":"puma management-server"')
+    end
+
+    it_behaves_like 'when non GET request'
+  end
+
+  describe 'with non existing endpoint' do
+    let(:endpoint) { '/notfound' }
+
+    it 'responds with 404' do
+      expect(response).to be_not_found.have_content_type('text/plain')
+      expect(response).to have_body('not found')
+    end
+  end
+
+  RSpec::Matchers.define :be_ok do
+    match { |actual| actual.is_a?(Net::HTTPOK) }
+  end
+
+  RSpec::Matchers.define :be_not_found do
+    match { |actual| actual.is_a?(Net::HTTPNotFound) }
+  end
+
+  RSpec::Matchers.define :have_content_type do |expected|
+    match { |actual| actual['Content-Type'] == expected }
+
+    failure_message do |actual|
+      "expected that #{actual['Content-Type'].inspect} is equals to #{expected.inspect}"
+    end
+  end
+
+  RSpec::Matchers.define :have_body do |expected|
+    match { |actual| actual.body.include? expected }
+
+    failure_message do |actual|
+      "expected that [#{actual.body}]\n" \
+      "contains [#{expected}]"
+    end
+  end
+end

--- a/spec/bm/instrumentations/management/server_spec.rb
+++ b/spec/bm/instrumentations/management/server_spec.rb
@@ -3,7 +3,7 @@
 require 'net/http'
 require 'bm/instrumentations'
 
-RSpec.describe BM::Instrumentations::Management::Server do
+RSpec.describe BM::Instrumentations::Management::Server, net_http: true do
   subject(:server_run) { described_class.run(host: host, port: 0, registry: registry) }
 
   let(:host) { '127.0.0.1' }
@@ -79,31 +79,6 @@ RSpec.describe BM::Instrumentations::Management::Server do
     it 'responds with 404' do
       expect(response).to be_not_found.have_content_type('text/plain')
       expect(response).to have_body('not found')
-    end
-  end
-
-  RSpec::Matchers.define :be_ok do
-    match { |actual| actual.is_a?(Net::HTTPOK) }
-  end
-
-  RSpec::Matchers.define :be_not_found do
-    match { |actual| actual.is_a?(Net::HTTPNotFound) }
-  end
-
-  RSpec::Matchers.define :have_content_type do |expected|
-    match { |actual| actual['Content-Type'] == expected }
-
-    failure_message do |actual|
-      "expected that #{actual['Content-Type'].inspect} is equals to #{expected.inspect}"
-    end
-  end
-
-  RSpec::Matchers.define :have_body do |expected|
-    match { |actual| actual.body.include? expected }
-
-    failure_message do |actual|
-      "expected that [#{actual.body}]\n" \
-      "contains [#{expected}]"
     end
   end
 end

--- a/spec/integrations/puma/plugin/management_server_spec.rb
+++ b/spec/integrations/puma/plugin/management_server_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe 'Puma::Plugin::ManagementServer', integration: true, net_http: tr
   end
 
   def wait_for(port, retries: 5)
-    puts "> #{host}:#{port} waiting for"
-    (1..retries).each do
+    (1..retries).each do |attempt|
       TCPSocket.new(host, port).close
-      puts "< #{host}:#{port} is ready"
-      return
+      break
     rescue Errno::ECONNREFUSED
+      raise if attempt == retries
+
       sleep 1
-      retry
+      next
     end
   end
 end

--- a/spec/integrations/puma/plugin/management_server_spec.rb
+++ b/spec/integrations/puma/plugin/management_server_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'puma'
+
+RSpec.describe 'Puma::Plugin::ManagementServer', integration: true, net_http: true do
+  let(:host) { '127.0.0.1' }
+  let(:management_port) { 3001 }
+  let(:puma_port) { 3000 }
+  let(:puma) do
+    Puma::Launcher.new(Puma::Configuration.new do |cfg|
+      cfg.bind "tcp://#{host}:#{puma_port}"
+      cfg.threads 1, 1
+
+      cfg.plugin(:management_server)
+      cfg.management_server(host: host, port: management_port)
+      cfg.app ->(_) { [200, {}, ['hello']] }
+    end)
+  end
+
+  before { Thread.new { puma.run } }
+
+  after { puma.stop }
+
+  it 'starts puma and management server' do
+    [puma_port, management_port].each { wait_for(_1) }
+
+    hello = Net::HTTP.get_response(URI("http://#{host}:#{puma_port}"))
+    expect(hello).to be_ok.have_body('hello')
+
+    pong = Net::HTTP.get_response(URI("http://#{host}:#{management_port}/ping"))
+    expect(pong).to be_ok.have_body('pong')
+  end
+
+  def wait_for(port, retries: 5)
+    puts "> #{host}:#{port} waiting for"
+    (1..retries).each do
+      TCPSocket.new(host, port).close
+      puts "< #{host}:#{port} is ready"
+      return
+    rescue Errno::ECONNREFUSED
+      sleep 1
+      retry
+    end
+  end
+end

--- a/spec/roda/plugins/prometheus_instrumentation_spec.rb
+++ b/spec/roda/plugins/prometheus_instrumentation_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe 'Roda::RodaPlugins::PrometheusInstrumentation', rack: true do
     cls.app.freeze
   end
 
-  it 'responds to /metrics' do
-    get '/metrics'
+  it 'collects metrics' do
+    expect { get '/' }.to change { requests_total }.by(1)
+  end
 
-    expect(last_response).to be_ok
-    expect(last_response['Content-Type']).to eq('text/plain; version=0.0.4')
-    expect(last_response.body).to include("TYPE http_server_requests_total counter\n")
-    expect(last_response.body).to include("TYPE http_server_request_duration_seconds histogram\n")
+  # @return [Integer]
+  def requests_total
+    registry.get(:http_server_requests_total)&.values&.size || 0
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,10 @@
 
 require 'bundler'
 
-require_relative 'support/simplecov_start' if ENV.fetch('SIMPLECOV', '0') != '0'
+require_relative 'support/simplecov_start' unless ENV.fetch('SIMPLECOV', '').empty?
 
 RSpec.configure do |config|
+  config.filter_run_excluding(integration: true) if ENV.fetch('INTEGRATION_SPECS', '').empty?
   config.example_status_persistence_file_path = '.rspec_status'
   config.disable_monkey_patching!
 
@@ -16,4 +17,5 @@ end
 require_relative 'support/rack_test_helper'
 require_relative 'support/registry_helper'
 require_relative 'support/non_listening_port_helper'
+require_relative 'support/net_http_matchers'
 require_relative 'support/shared_examples'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,5 @@ end
 
 require_relative 'support/rack_test_helper'
 require_relative 'support/registry_helper'
+require_relative 'support/non_listening_port_helper'
 require_relative 'support/shared_examples'

--- a/spec/support/net_http_matchers.rb
+++ b/spec/support/net_http_matchers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+RSpec.configure do |config|
+  config.include(Module.new do
+    extend RSpec::Matchers::DSL
+
+    matcher :be_ok do
+      match { |actual| actual.is_a?(Net::HTTPOK) }
+    end
+
+    matcher :be_not_found do
+      match { |actual| actual.is_a?(Net::HTTPNotFound) }
+    end
+
+    matcher :have_content_type do |expected|
+      match { |actual| actual['Content-Type'] == expected }
+
+      failure_message do |actual|
+        "expected that #{actual['Content-Type'].inspect} is equals to #{expected.inspect}"
+      end
+    end
+
+    matcher :have_body do |expected|
+      match { |actual| actual.body.include? expected }
+
+      failure_message do |actual|
+        "expected that [#{actual.body}]\n" \
+      "contains [#{expected}]"
+      end
+    end
+  end, net_http: true)
+end

--- a/spec/support/non_listening_port_helper.rb
+++ b/spec/support/non_listening_port_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'socket'
+
+RSpec.configure do |config|
+  config.include(Module.new do
+    # Returns a free TCP port that never listened
+    #
+    # @return [Integer]
+    def non_listening_port
+      @non_listening_port ||= begin
+        server = TCPServer.new('127.0.0.1', 0)
+        server.addr[1]
+      ensure
+        server&.close
+      end
+    end
+  end)
+end

--- a/spec/support/simplecov_start.rb
+++ b/spec/support/simplecov_start.rb
@@ -8,6 +8,11 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter
 ]
 
+command_name = ENV.fetch('SIMPLECOV_COMMAND_NAME', '')
+command_name = 'unit' if command_name.empty?
+SimpleCov.command_name command_name
+SimpleCov.coverage_dir(File.expand_path("../../coverage/#{command_name}", __dir__))
+
 SimpleCov.start do
   add_filter '/spec/'
   track_files 'lib/**/*.rb'


### PR DESCRIPTION
The `BM::Instrumentations::Management::Server` and corresponding Puma plugin. 
See [README.md](https://github.com/bookmate/bm-instrumentations/blob/menagement-server/README.md#management-server-puma-plugin)

Also, added integration specs that needs to testing puma plugins, each integration spec runs in separate process.