### PR TITLE
Add custom collectors to Prometheus registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to use custom metric collectors
+
 ### Changed
 
 - __Breaking__ The class `BM::Instrumentations::Aws::Collector` turned into gem private,

--- a/lib/bm/instrumentations/internal/prometheus_registry_custom_collectors.rb
+++ b/lib/bm/instrumentations/internal/prometheus_registry_custom_collectors.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module BM
+  module Instrumentations
+    # Extends the Prometheus registry to support custom metric collectors
+    #
+    # @see https://github.com/prometheus/client_ruby/issues/90
+    module PrometheusRegistryCustomCollectors
+      # Initialize custom_collectors array
+      def initialize(*args, **kwargs)
+        super(*args, **kwargs)
+        @custom_collectors = []
+      end
+
+      # Registers an updater that poll and update metrics periodically
+      #
+      # @param collector [Proc]
+      def add_custom_collector(&collector)
+        @mutex.synchronize do
+          @custom_collectors << collector
+        end
+      end
+
+      # Invokes all registered custom collectors to update metrics
+      #
+      # @return [void]
+      def custom_collectors!
+        @custom_collectors.each(&:call)
+      end
+    end
+  end
+end
+
+Prometheus::Client::Registry.prepend(BM::Instrumentations::PrometheusRegistryCustomCollectors)

--- a/lib/puma/plugin/management_server.rb
+++ b/lib/puma/plugin/management_server.rb
@@ -3,6 +3,7 @@
 require 'puma/dsl'
 require 'puma/plugin'
 require 'bm/instrumentations'
+require 'bm/instrumentations/puma/collector'
 
 module BM
   module Instrumentations
@@ -40,13 +41,13 @@ Puma::Plugin.create do
       host: launcher.options[:management_server_host],
       port: launcher.options[:management_server_port],
       logger: launcher.options[:management_server_logger],
-      registry: launcher.options[:management_server_registry],
-      puma_launcher: launcher
+      registry: launcher.options[:management_server_registry]
     }
 
     # @type [Puma::Events]
     events = launcher.events
     server = BM::Instrumentations::Management.server(**args)
+    BM::Instrumentations::Puma::Collector.install(launcher, registry: args[:registry])
 
     events.on_booted do
       running = server.run


### PR DESCRIPTION
The gem `prometheus-client` doesn't support a custom collectors, see [issue #90](https://github.com/prometheus/client_ruby/issues/90). This PL add missing functionality, but only if the management server is used.