### PR TITLE
Add metrics collector for Ruby VM & GC stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Ability to use custom metric collectors
+- Add ability to use custom metric collectors
+- Add a custom collector for Ruby VM & GC stats
 
 ### Changed
 
-- __Breaking__ The class `BM::Instrumentations::Aws::Collector` turned into gem private,
+- __BREAKING__ The class `BM::Instrumentations::Aws::Collector` turned into gem private,
   the method `BM::Instrumentations::Aws.plugin` should be use to include the plugin
-- __Breaking__ The class `BM::Instrumentations::Management::Server` turned into gem private,
+- __BREAKING__ The class `BM::Instrumentations::Management::Server` turned into gem private,
   the method `BM::Instrumentations::Management.server` should be use to create a server
-- __Breaking__ The middleware `BM::Instrumentations::Rack::Collector` renamed to 
+- __BREAKING__ The middleware `BM::Instrumentations::Rack::Collector` renamed to 
   `BM::Instrumentations::Rack`
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -255,7 +255,11 @@ with `BM::Instrumentations::Management::Server` together.
 ```ruby
 require 'bm/instrumentations'
 
+# It installs a custom collector to the default prometheus registry
 BM::Instrumentations::RubyVM.install
+
+# Or if you don't want to activate GC::Profiler
+BM::Instrumentations::RubyVM.install(enable_gc_profiler: false)
 ```
 
 #### Collected metrics

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ management_server(host: '127.0.0.1', port: 9000, logger: Logger.new(IO::NULL))
 
 <hr>
 
-# Ruby VM & GC metrics
+## Ruby VM & GC metrics
 
 `BM::Instrumentation::RubyVM` is a custom metrics collector that captures ruby's VM and GC stats. Due to the official
 prometheus client for ruby isn't yet support that types of collectors, so the collectors only works

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Rack, S3, Roda and etc.
 * [Ruby Method Metrics](#ruby-methods-metrics)
 * [Endpoint Name Roda Plugin](#endpoint-name-roda-plugin)
 * [Management Server Puma plugin](#management-server-puma-plugin)
+* [Ruby VM & GC Metrics](#ruby-vm--gc-metrics)
 
 <hr>
 
@@ -175,7 +176,7 @@ end
 
 <hr>
 
-# Endpoint Name Roda plugin
+## Endpoint Name Roda plugin
 
 The `endpoint` plugin adds an endpoint name to the Rack's request env.
 
@@ -209,7 +210,7 @@ end
 
 <hr>
 
-# Management Server Puma plugin
+## Management Server Puma plugin
 
 The `management_server` plugin provides monitoring and metrics on different HTTP port, it starts a separated
 `Puma::Server` that serves requests.
@@ -242,6 +243,33 @@ management_server(host: '127.0.0.1', port: 9000, logger: Logger.new(IO::NULL))
 | `puma_thread_pool_queue_size` | gauge | - | The number of queued requests that waiting execution in the Puma server |
 | `puma_server_socket_backlog_size` | gauge | `listener` | __Linux only__<br>The current size of the pending connection queue of the Puma listener | 
 | `puma_server_socket_backlog_max_size` | gauge | `listener` | __Linux only__<br>The preconfigured maximum size of the pending connections queue of the Puma listener |
+
+<hr>
+
+# Ruby VM & GC metrics
+
+`BM::Instrumentation::RubyVM` is a custom metrics collector that captures ruby's VM and GC stats. Due to the official
+prometheus client for ruby isn't yet support that types of collectors, so the collectors only works
+with `BM::Instrumentations::Management::Server` together.
+
+```ruby
+require 'bm/instrumentations'
+
+BM::Instrumentations::RubyVM.install
+```
+
+#### Collected metrics
+
+| Metrics | Type | Labels | Description |
+|---------|------|--------|-------------|
+| `ruby_version` | gauge | `ruby`<br>`version` | The current ruby engine name and version |
+| `ruby_gc_time_seconds` | summary | | The total time that Ruby GC spends for garbage collection in seconds |
+| `ruby_gc_heap_slots_size` | gauge | `slots` | The size of available heap slots of Ruby GC partitioned by slots type (`free` or `live`) |
+| `ruby_gc_allocated_objects_total` | gauge | | The total number of allocated objects by Ruby GC |
+| `ruby_gc_freed_objects_total` | gauge | | The total number of freed objects by Ruby GC |
+| `ruby_gc_counts_total` | gauge | `counts` | The total number of Ruby GC counts partitioned by counts type (`minor` or `major`) |
+| `ruby_vm_global_cache_state` | gauge | `cache` | The Ruby VM global cache state (version) for methods and constants, partitioned by cache type (`method` or `constant`) |
+| `ruby_threads_count` | gauge | | The number of running threads |
 
 # License
 

--- a/lib/bm/instrumentations.rb
+++ b/lib/bm/instrumentations.rb
@@ -13,6 +13,7 @@ module BM
     autoload :Aws,            'bm/instrumentations/aws/collector'
     autoload :Management,     'bm/instrumentations/management/server'
     autoload :Rack,           'bm/instrumentations/rack/middleware'
+    autoload :RubyVM,         'bm/instrumentations/ruby_vm/collector'
     autoload :Puma,           'bm/instrumentations/puma/collector'
   end
 end

--- a/lib/bm/instrumentations/puma/collector.rb
+++ b/lib/bm/instrumentations/puma/collector.rb
@@ -13,6 +13,8 @@ module BM
     # It it a custom collector that poll metrics periodically and currently working only if the
     # management server is used.
     module Puma
+      # Puma metrics collector, collects thread pool stats and optionally socket backlog stats
+      #
       # @attr [MetricsCollection] metrics_collection
       # @attr [Puma::Launcher] launcher
       # @attr [TcpInfo] tcp_info
@@ -47,11 +49,10 @@ module BM
         end
       end
 
-      # Installs a custom collector into {Prometheus::Registry}
+      # Puma metrics collector, collects thread pool stats and optionally socket backlog stats
       #
       # @param launcher [Puma::Launcher]
       # @param registry [Prometheus::Client::Registry, nil]
-      # @return [void]
       def self.install(launcher, registry: nil)
         registry ||= Prometheus::Client.registry
         registry.add_custom_collector(&Collector.new(registry: registry, launcher: launcher))

--- a/lib/bm/instrumentations/puma/collector.rb
+++ b/lib/bm/instrumentations/puma/collector.rb
@@ -13,7 +13,10 @@ module BM
     # It it a custom collector that poll metrics periodically and currently working only if the
     # management server is used.
     module Puma
-      # Puma metrics collector, collects thread pool stats and optionally socket backlog stats
+      # Puma metrics collector, collects thread pool stats and optionally socket backlog stats.
+      #
+      # It it a custom collector that poll metrics periodically and currently working only if the
+      # management server is used.
       #
       # @attr [MetricsCollection] metrics_collection
       # @attr [Puma::Launcher] launcher

--- a/lib/bm/instrumentations/puma/collector.rb
+++ b/lib/bm/instrumentations/puma/collector.rb
@@ -13,11 +13,6 @@ module BM
     # It it a custom collector that poll metrics periodically and currently working only if the
     # management server is used.
     module Puma
-      # Puma metrics collector, collects thread pool stats and optionally socket backlog stats.
-      #
-      # It it a custom collector that poll metrics periodically and currently working only if the
-      # management server is used.
-      #
       # @attr [MetricsCollection] metrics_collection
       # @attr [Puma::Launcher] launcher
       # @attr [TcpInfo] tcp_info
@@ -52,10 +47,11 @@ module BM
         end
       end
 
-      # Puma metrics collector, collects thread pool stats and optionally socket backlog stats
+      # Installs a custom collector into {Prometheus::Registry}
       #
       # @param launcher [Puma::Launcher]
       # @param registry [Prometheus::Client::Registry, nil]
+      # @return [void]
       def self.install(launcher, registry: nil)
         registry ||= Prometheus::Client.registry
         registry.add_custom_collector(&Collector.new(registry: registry, launcher: launcher))

--- a/lib/bm/instrumentations/ruby_vm/collector.rb
+++ b/lib/bm/instrumentations/ruby_vm/collector.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative 'metrics_collection'
+
+module BM
+  module Instrumentations
+    # Collects Ruby VM and GC metrics
+    module RubyVM
+      # Collects Ruby VM and GC metrics
+      #
+      # @attr [MetricsCollection] metrics_collection
+      class Collector
+        attr_reader :metrics_collection
+
+        SLOTS_FREE = { labels: { slots: 'free' } }.freeze
+        SLOTS_LIVE = { labels: { slots: 'live' } }.freeze
+        CACHE_METHOD = { labels: { cache: 'method' } }.freeze
+        CACHE_CONSTANT = { labels: { cache: 'constant' } }.freeze
+
+        # @param registry [Prometheus::Client::Registry]
+        # @api private
+        def initialize(registry)
+          @metrics_collection = MetricsCollection.new(registry)
+        end
+
+        # @return [void]
+        def update
+          update_gc_profiler_total_time if GC::Profiler.enabled?
+          update_gc_stats(::GC.stat)
+          update_global_cache(::RubyVM.stat)
+          metrics_collection.threads_count.set(::Thread.list.size)
+        end
+
+        # @return [Proc]
+        def to_proc
+          -> { update }
+        end
+
+        private
+
+        # @param gc_stats [Hash<Symbol, Integer>]
+        # @option gc_stats [Integer] :heap_free_slots
+        # @option gc_stats [Integer] :heap_live_slots
+        # @option gc_stats [Integer] :total_allocated_objects
+        # @option gc_stats [Integer] :total_freed_objects
+        def update_gc_stats(gc_stats)
+          metrics_collection.gc_heap_slots_size.set(gc_stats[:heap_free_slots], SLOTS_FREE)
+          metrics_collection.gc_heap_slots_size.set(gc_stats[:heap_live_slots], SLOTS_LIVE)
+          metrics_collection.gc_allocated_objects_total.set(gc_stats[:total_allocated_objects])
+          metrics_collection.gc_freed_objects_total.set(gc_stats[:total_freed_objects])
+        end
+
+        # @param vm_stats [Hash<Symbol, Integer>]
+        # @option vm_stats [Integer] :global_method_state
+        # @option vm_stats [Integer] :global_constant_state
+        def update_global_cache(vm_stats)
+          return unless %i[global_method_state global_constant_state].all? { vm_stats.include?(_1) }
+
+          metrics_collection.vm_global_cache_state.set(vm_stats[:global_method_state], CACHE_METHOD)
+          metrics_collection.vm_global_cache_state.set(vm_stats[:global_constant_state], CACHE_CONSTANT)
+        end
+
+        # Records {GC::Profiler.total_time} if it's enabled
+        #
+        # By default {GC::Profile} is disabled and total time always zero, to get non zero values
+        # the GC profiler should be enabled by calling {GC::Profiler.enable}
+        def update_gc_profiler_total_time
+          total_time = GC::Profiler.total_time
+          metrics_collection.gc_time_seconds.observe(total_time.round(6))
+        ensure
+          GC::Profiler.clear
+        end
+      end
+
+      # @param registry [Prometheus::Client::Registry]
+      # @param enable_gc_profiler [Boolean]
+      # @return [void]
+      def self.install(registry = nil, enable_gc_profiler: false)
+        ::GC::Profiler.enable if enable_gc_profiler
+
+        registry ||= Prometheus::Client.registry
+        registry.add_custom_collector(&Collector.new(registry))
+      end
+    end
+  end
+end

--- a/lib/bm/instrumentations/ruby_vm/collector.rb
+++ b/lib/bm/instrumentations/ruby_vm/collector.rb
@@ -62,18 +62,11 @@ module BM
         # @option vm_stats [Integer] :global_constant_state
         def update_global_cache(vm_stats)
           if vm_stats[:global_method_state]
-            metrics_collection.vm_global_cache_state.set(
-              vm_stats[:global_method_state],
-              **CACHE_METHOD
-            )
+            metrics_collection.vm_global_cache_state.set(vm_stats[:global_method_state], **CACHE_METHOD)
           end
+          return unless vm_stats[:global_constant_state]
 
-          if vm_stats[:global_constant_state]
-            metrics_collection.vm_global_cache_state.set(
-              vm_stats[:global_constant_state],
-              **CACHE_CONSTANT
-            )
-          end
+          metrics_collection.vm_global_cache_state.set(vm_stats[:global_constant_state], **CACHE_CONSTANT)
         end
 
         # Records {GC::Profiler.total_time} if it's enabled

--- a/lib/bm/instrumentations/ruby_vm/collector.rb
+++ b/lib/bm/instrumentations/ruby_vm/collector.rb
@@ -7,7 +7,13 @@ module BM
   module Instrumentations
     # Collects Ruby VM and GC metrics
     module RubyVM
-      # Collects Ruby VM and GC metrics
+      # Collects Ruby VM and GC stats and write to Prometheus.
+      #
+      # It it a custom collector that poll metrics periodically and currently working only if the
+      # management server is used.
+      #
+      # @example Usage
+      #   BM::Instrumentations::Ruby.install
       #
       # @attr [MetricsCollection] metrics_collection
       # @api private

--- a/lib/bm/instrumentations/ruby_vm/collector.rb
+++ b/lib/bm/instrumentations/ruby_vm/collector.rb
@@ -10,6 +10,7 @@ module BM
       # Collects Ruby VM and GC metrics
       #
       # @attr [MetricsCollection] metrics_collection
+      # @api private
       class Collector
         attr_reader :metrics_collection
 
@@ -21,7 +22,6 @@ module BM
         MAJOR_GC_COUNT = { labels: { counts: 'major' } }.freeze
 
         # @param registry [Prometheus::Client::Registry]
-        # @api private
         def initialize(registry)
           @metrics_collection = MetricsCollection.new(registry)
         end

--- a/lib/bm/instrumentations/ruby_vm/collector.rb
+++ b/lib/bm/instrumentations/ruby_vm/collector.rb
@@ -61,10 +61,19 @@ module BM
         # @option vm_stats [Integer] :global_method_state
         # @option vm_stats [Integer] :global_constant_state
         def update_global_cache(vm_stats)
-          return unless %i[global_method_state global_constant_state].all? { vm_stats.include?(_1) }
+          if vm_stats[:global_method_state]
+            metrics_collection.vm_global_cache_state.set(
+              vm_stats[:global_method_state],
+              **CACHE_METHOD
+            )
+          end
 
-          metrics_collection.vm_global_cache_state.set(vm_stats[:global_method_state], **CACHE_METHOD)
-          metrics_collection.vm_global_cache_state.set(vm_stats[:global_constant_state], **CACHE_CONSTANT)
+          if vm_stats[:global_constant_state]
+            metrics_collection.vm_global_cache_state.set(
+              vm_stats[:global_constant_state],
+              **CACHE_CONSTANT
+            )
+          end
         end
 
         # Records {GC::Profiler.total_time} if it's enabled

--- a/lib/bm/instrumentations/ruby_vm/collector.rb
+++ b/lib/bm/instrumentations/ruby_vm/collector.rb
@@ -49,12 +49,12 @@ module BM
         # @option gc_stats [Integer] :minor_gc_count
         # @option gc_stats [Integer] :major_gc_count
         def update_gc_stats(gc_stats) # rubocop:disable Metrics/AbcSize
-          metrics_collection.gc_heap_slots_size.set(gc_stats[:heap_free_slots], SLOTS_FREE)
-          metrics_collection.gc_heap_slots_size.set(gc_stats[:heap_live_slots], SLOTS_LIVE)
+          metrics_collection.gc_heap_slots_size.set(gc_stats[:heap_free_slots], **SLOTS_FREE)
+          metrics_collection.gc_heap_slots_size.set(gc_stats[:heap_live_slots], **SLOTS_LIVE)
           metrics_collection.gc_allocated_objects_total.set(gc_stats[:total_allocated_objects])
           metrics_collection.gc_freed_objects_total.set(gc_stats[:total_freed_objects])
-          metrics_collection.gc_counts_total.set(gc_stats[:minor_gc_count], MINOR_GC_COUNT)
-          metrics_collection.gc_counts_total.set(gc_stats[:major_gc_count], MAJOR_GC_COUNT)
+          metrics_collection.gc_counts_total.set(gc_stats[:minor_gc_count], **MINOR_GC_COUNT)
+          metrics_collection.gc_counts_total.set(gc_stats[:major_gc_count], **MAJOR_GC_COUNT)
         end
 
         # @param vm_stats [Hash<Symbol, Integer>]
@@ -63,8 +63,8 @@ module BM
         def update_global_cache(vm_stats)
           return unless %i[global_method_state global_constant_state].all? { vm_stats.include?(_1) }
 
-          metrics_collection.vm_global_cache_state.set(vm_stats[:global_method_state], CACHE_METHOD)
-          metrics_collection.vm_global_cache_state.set(vm_stats[:global_constant_state], CACHE_CONSTANT)
+          metrics_collection.vm_global_cache_state.set(vm_stats[:global_method_state], **CACHE_METHOD)
+          metrics_collection.vm_global_cache_state.set(vm_stats[:global_constant_state], **CACHE_CONSTANT)
         end
 
         # Records {GC::Profiler.total_time} if it's enabled

--- a/lib/bm/instrumentations/ruby_vm/metrics_collection.rb
+++ b/lib/bm/instrumentations/ruby_vm/metrics_collection.rb
@@ -56,8 +56,8 @@ module BM
           @gc_heap_slots_size = register_metric(registry, :ruby_gc_heap_slots_size) do |name|
             registry.gauge(
               name,
-              docstring: 'The size of available heap slots of Ruby GC partitioned by type',
-              labels: %i[slot_type]
+              docstring: 'The size of available heap slots of Ruby GC partitioned by slots type',
+              labels: %i[slots]
             )
           end
         end
@@ -87,8 +87,8 @@ module BM
           @gc_counts_total = register_metric(registry, :ruby_gc_counts_total) do |name|
             registry.gauge(
               name,
-              docstring: 'The total number of Ruby GC counts partitioned by type',
-              labels: %i[count_type]
+              docstring: 'The total number of Ruby GC counts partitioned by counts type',
+              labels: %i[counts]
             )
           end
         end
@@ -98,8 +98,9 @@ module BM
           @vm_global_cache_state = register_metric(registry, :ruby_vm_global_cache_state) do |name|
             registry.gauge(
               name,
-              docstring: 'The Ruby VM global cache state (version) for methods and constants, partitioned by type',
-              labels: %i[cache_type]
+              docstring: 'The Ruby VM global cache state (version) for methods and constants,' \
+                         ' partitioned by cache type',
+              labels: %i[cache]
             )
           end
         end

--- a/lib/bm/instrumentations/ruby_vm/metrics_collection.rb
+++ b/lib/bm/instrumentations/ruby_vm/metrics_collection.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module BM
+  module Instrumentations
+    module RubyVM
+      # @attr [Prometheus::Client::Summary] gc_time_seconds
+      # @attr [Prometheus::Client::Gauge] gc_heap_slots_size
+      # @attr [Prometheus::Client::Gauge] gc_allocated_objects_total
+      # @attr [Prometheus::Client::Gauge] gc_freed_objects_total
+      # @attr [Prometheus::Client::Gauge] gc_counts_total
+      # @attr [Prometheus::Client::Gauge] vm_global_cache_state
+      # @attr [Prometheus::Client::Gauge] threads_count
+      class MetricsCollection
+        include RegisterMetric
+
+        attr_reader :gc_time_seconds, :gc_heap_slots_size, :gc_allocated_objects_total,
+                    :gc_freed_objects_total, :gc_counts_total, :vm_global_cache_state, :threads_count
+
+        def initialize(registry)
+          build_version(registry)
+          build_gc_time_seconds(registry)
+          build_gc_heap_slots_size(registry)
+          build_gc_allocated_objects_total(registry)
+          build_gc_freed_objects_total(registry)
+          build_gc_counts_total(registry)
+          build_vm_global_cache_state(registry)
+          build_threads_count(registry)
+        end
+
+        private
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_version(registry)
+          version = register_metric(registry, :ruby_version) do |name|
+            registry.gauge(
+              name,
+              docstring: 'The Ruby VM version',
+              labels: %i[ruby version]
+            )
+          end
+          version.set(1, labels: { ruby: RUBY_ENGINE, version: RUBY_ENGINE_VERSION })
+        end
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_gc_time_seconds(registry)
+          @gc_time_seconds = register_metric(registry, :ruby_gc_time_seconds) do |name|
+            registry.summary(
+              name,
+              docstring: 'The total time that Ruby GC spends for garbage collection in seconds'
+            )
+          end
+        end
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_gc_heap_slots_size(registry)
+          @gc_heap_slots_size = register_metric(registry, :ruby_gc_heap_slots_size) do |name|
+            registry.gauge(
+              name,
+              docstring: 'The size of available heap slots of Ruby GC partitioned by type',
+              labels: %i[slot_type]
+            )
+          end
+        end
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_gc_allocated_objects_total(registry)
+          @gc_allocated_objects_total = register_metric(registry, :ruby_gc_allocated_objects_total) do |name|
+            registry.gauge(
+              name,
+              docstring: 'The total number of allocated objects by Ruby GC'
+            )
+          end
+        end
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_gc_freed_objects_total(registry)
+          @gc_freed_objects_total = register_metric(registry, :ruby_gc_freed_objects_total) do |name|
+            registry.gauge(
+              name,
+              docstring: 'The total number of freed objects by Ruby GC'
+            )
+          end
+        end
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_gc_counts_total(registry)
+          @gc_counts_total = register_metric(registry, :ruby_gc_counts_total) do |name|
+            registry.gauge(
+              name,
+              docstring: 'The total number of Ruby GC counts partitioned by type',
+              labels: %i[count_type]
+            )
+          end
+        end
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_vm_global_cache_state(registry)
+          @vm_global_cache_state = register_metric(registry, :ruby_vm_global_cache_state) do |name|
+            registry.gauge(
+              name,
+              docstring: 'The Ruby VM global cache state (version) for methods and constants, partitioned by type',
+              labels: %i[cache_type]
+            )
+          end
+        end
+
+        # @param registry [Prometheus::Client::Registry]
+        def build_threads_count(registry)
+          @threads_count = register_metric(registry, :ruby_threads_count) do |name|
+            registry.gauge(
+              name,
+              docstring: 'The number of running threads'
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bm/instrumentations/ruby_vm/metrics_collection.rb
+++ b/lib/bm/instrumentations/ruby_vm/metrics_collection.rb
@@ -3,6 +3,8 @@
 module BM
   module Instrumentations
     module RubyVM
+      # A collection of Prometheus metrics for Ruby VM & GC
+      #
       # @attr [Prometheus::Client::Summary] gc_time_seconds
       # @attr [Prometheus::Client::Gauge] gc_heap_slots_size
       # @attr [Prometheus::Client::Gauge] gc_allocated_objects_total
@@ -16,6 +18,7 @@ module BM
         attr_reader :gc_time_seconds, :gc_heap_slots_size, :gc_allocated_objects_total,
                     :gc_freed_objects_total, :gc_counts_total, :vm_global_cache_state, :threads_count
 
+        # @param registry [Prometheus::Client::Registry]
         def initialize(registry)
           build_version(registry)
           build_gc_time_seconds(registry)

--- a/spec/bm/instrumentations/ruby_vm/collector_spec.rb
+++ b/spec/bm/instrumentations/ruby_vm/collector_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'bm/instrumentations'
+
+RSpec.describe BM::Instrumentations::RubyVM::Collector do
+  before do
+    BM::Instrumentations::RubyVM.install(registry, enable_gc_profiler: true)
+  end
+
+  it 'registers metrics in registry' do
+    expect(registry.get(:ruby_gc_time_seconds)).to be_kind_of(Prometheus::Client::Summary)
+    expect(registry.get(:ruby_gc_heap_slots_size)).to be_kind_of(Prometheus::Client::Gauge)
+    expect(registry.get(:ruby_gc_allocated_objects_total)).to be_kind_of(Prometheus::Client::Gauge)
+    expect(registry.get(:ruby_gc_freed_objects_total)).to be_kind_of(Prometheus::Client::Gauge)
+    expect(registry.get(:ruby_gc_counts_total)).to be_kind_of(Prometheus::Client::Gauge)
+    expect(registry.get(:ruby_vm_global_cache_state)).to be_kind_of(Prometheus::Client::Gauge)
+    expect(registry.get(:ruby_threads_count)).to be_kind_of(Prometheus::Client::Gauge)
+  end
+
+  describe '#update' do
+    subject(:update) do
+      (1..1_000_000).to_a.each { _1 }
+      GC.start
+      registry.update_custom_collectors
+    end
+
+    before { update }
+
+    it 'increments a :ruby_gc_time_seconds summary' do
+      expect(gauge_value(:ruby_gc_time_seconds)).to include('count' => 1.0, 'sum' => be_positive)
+    end
+
+    it 'increments a :ruby_gc_heap_slots_size gauge' do
+      expect(gauge_value(:ruby_gc_heap_slots_size, slots: 'free')).to be_positive
+      expect(gauge_value(:ruby_gc_heap_slots_size, slots: 'live')).to be_positive
+    end
+
+    it 'increments a :ruby_gc_allocated_objects_total gauge' do
+      expect(gauge_value(:ruby_gc_allocated_objects_total)).to be_positive
+    end
+
+    it 'increments a :ruby_gc_freed_objects_total gauge' do
+      expect(gauge_value(:ruby_gc_freed_objects_total)).to be_positive
+    end
+
+    it 'increments a :ruby_gc_counts_total gauge' do
+      expect(gauge_value(:ruby_gc_counts_total, counts: 'minor')).to be_positive
+      expect(gauge_value(:ruby_gc_counts_total, counts: 'major')).to be_positive
+    end
+
+    it 'increments a :ruby_vm_global_cache_state gauge' do
+      expect(gauge_value(:ruby_vm_global_cache_state, cache: 'method')).to be_positive
+      expect(gauge_value(:ruby_vm_global_cache_state, cache: 'constant')).to be_positive
+    end
+
+    it 'increments a :ruby_threads_count gauge' do
+      expect(gauge_value(:ruby_threads_count)).to be_positive
+    end
+  end
+end

--- a/spec/bm/instrumentations/ruby_vm/collector_spec.rb
+++ b/spec/bm/instrumentations/ruby_vm/collector_spec.rb
@@ -48,8 +48,13 @@ RSpec.describe BM::Instrumentations::RubyVM::Collector do
       expect(gauge_value(:ruby_gc_counts_total, counts: 'major')).to be_positive
     end
 
-    it 'increments a :ruby_vm_global_cache_state gauge' do
+    it 'increments a :ruby_vm_global_cache_state gauge', 'with method' do
+      skip('Not for ruby3') if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+
       expect(gauge_value(:ruby_vm_global_cache_state, cache: 'method')).to be_positive
+    end
+
+    it 'increments a :ruby_vm_global_cache_state gauge', 'with constant' do
       expect(gauge_value(:ruby_vm_global_cache_state, cache: 'constant')).to be_positive
     end
 


### PR DESCRIPTION
See [README](https://github.com/bookmate/bm-instrumentations/tree/ruby-vn-metrics2#ruby-vm--gc-metrics)

- [x] add `BM::Instrumentations::RubyVM::Collector` custom collector
- [x] add specs for `BM::Instrumentations::RubyVM::Collector`
- [x] update README
- [x] update CHANGELOG