### PR TITLE
Update the custom collectors feature

### DIFF
--- a/lib/bm/instrumentations.rb
+++ b/lib/bm/instrumentations.rb
@@ -4,7 +4,8 @@ require 'prometheus/client'
 require 'bm/instrumentations/version'
 
 module BM
-  # :nodoc:
+  # Provides Prometheus metrics collectors and integrations for Sequel,
+  # Rack, S3, Roda and etc.
   module Instrumentations
     autoload :RegisterMetric, 'bm/instrumentations/internal/register_metric'
     autoload :Stopwatch,      'bm/instrumentations/internal/stopwatch'
@@ -12,5 +13,6 @@ module BM
     autoload :Aws,            'bm/instrumentations/aws/collector'
     autoload :Management,     'bm/instrumentations/management/server'
     autoload :Rack,           'bm/instrumentations/rack/middleware'
+    autoload :Puma,           'bm/instrumentations/puma/collector'
   end
 end

--- a/lib/bm/instrumentations/internal/prometheus_registry_custom_collectors.rb
+++ b/lib/bm/instrumentations/internal/prometheus_registry_custom_collectors.rb
@@ -6,17 +6,12 @@ module BM
     #
     # @see https://github.com/prometheus/client_ruby/issues/90
     module PrometheusRegistryCustomCollectors
-      # Initialize custom_collectors array
-      def initialize(*args, **kwargs)
-        super(*args, **kwargs)
-        @custom_collectors = []
-      end
-
-      # Registers an updater that poll and update metrics periodically
+      # Registers a custom collector that poll and update metrics periodically
       #
       # @param collector [Proc]
       def add_custom_collector(&collector)
         @mutex.synchronize do
+          @custom_collectors ||= []
           @custom_collectors << collector
         end
       end
@@ -24,11 +19,13 @@ module BM
       # Invokes all registered custom collectors to update metrics
       #
       # @return [void]
-      def custom_collectors!
+      def update_custom_collectors
+        return unless @custom_collectors
+
         @custom_collectors.each(&:call)
       end
     end
   end
 end
 
-Prometheus::Client::Registry.prepend(BM::Instrumentations::PrometheusRegistryCustomCollectors)
+Prometheus::Client::Registry.include(BM::Instrumentations::PrometheusRegistryCustomCollectors)

--- a/lib/bm/instrumentations/management/server.rb
+++ b/lib/bm/instrumentations/management/server.rb
@@ -4,7 +4,6 @@ require 'rack'
 require 'logger'
 require 'puma'
 require 'prometheus/client/formats/text'
-require 'bm/instrumentations/puma/collector'
 
 module BM
   module Instrumentations
@@ -181,7 +180,7 @@ module BM
 
           # @return [(Integer, Hash<String, String>, Array<String>)]
           def metrics
-            @registry.custom_collectors! if @registry.respond_to?(:custom_collectors!)
+            @registry.update_custom_collectors if @registry.respond_to?(:update_custom_collectors)
 
             text = Prometheus::Client::Formats::Text.marshal(@registry)
             [200, METRICS_TEXT, [text]]

--- a/lib/bm/instrumentations/puma/collector.rb
+++ b/lib/bm/instrumentations/puma/collector.rb
@@ -8,6 +8,10 @@ require_relative 'tcp_info'
 
 module BM
   module Instrumentations
+    # Puma metrics collector, collects thread pool stats and optionally socket backlog stats.
+    #
+    # It it a custom collector that poll metrics periodically and currently working only if the
+    # management server is used.
     module Puma
       # @attr [MetricsCollection] metrics_collection
       # @attr [Puma::Launcher] launcher
@@ -41,16 +45,16 @@ module BM
             metrics_collection.update_backlog(listener: index, backlog: tcp_info.of(io))
           end
         end
+      end
 
-        # Puma metrics collector, collects thread pool stats and optionally socket backlog stats
-        #
-        # @param launcher [Puma::Launcher]
-        # @param registry [Prometheus::Client::Registry, nil]
-        # @return [void]
-        def self.install(launcher, registry: nil)
-          registry ||= Prometheus::Client.registry
-          registry.add_custom_collector(&Collector.new(registry: registry, launcher: launcher))
-        end
+      # Installs a custom collector into {Prometheus::Registry}
+      #
+      # @param launcher [Puma::Launcher]
+      # @param registry [Prometheus::Client::Registry, nil]
+      # @return [void]
+      def self.install(launcher, registry: nil)
+        registry ||= Prometheus::Client.registry
+        registry.add_custom_collector(&Collector.new(registry: registry, launcher: launcher))
       end
     end
   end

--- a/lib/puma/plugin/management_server.rb
+++ b/lib/puma/plugin/management_server.rb
@@ -3,7 +3,6 @@
 require 'puma/dsl'
 require 'puma/plugin'
 require 'bm/instrumentations'
-require 'bm/instrumentations/puma/collector'
 
 module BM
   module Instrumentations
@@ -47,7 +46,7 @@ Puma::Plugin.create do
     # @type [Puma::Events]
     events = launcher.events
     server = BM::Instrumentations::Management.server(**args)
-    BM::Instrumentations::Puma::Collector.install(launcher, registry: args[:registry])
+    BM::Instrumentations::Puma.install(launcher, registry: args[:registry])
 
     events.on_booted do
       running = server.run

--- a/spec/bm/instrumentations/puma/collector_spec.rb
+++ b/spec/bm/instrumentations/puma/collector_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'bm/instrumentations'
-require 'bm/instrumentations/puma/collector'
 
 RSpec.describe BM::Instrumentations::Puma::Collector do
   let(:launcher) { instance_double('Puma::Launcher') }
@@ -14,11 +13,11 @@ RSpec.describe BM::Instrumentations::Puma::Collector do
     }
   end
 
-  let(:update) { registry.custom_collectors! }
+  let(:update) { registry.update_custom_collectors }
   let(:tcp_server) { TCPServer.new(0).tap { _1.listen(12) } }
 
   before do
-    described_class.install(launcher, registry: registry)
+    BM::Instrumentations::Puma.install(launcher, registry: registry)
 
     binder = instance_double('Puma::Binder')
     allow(launcher).to receive(:stats).and_return(stats)


### PR DESCRIPTION
Changes:

- Don't use `#initialize` at `PrometheusRegistryCustomCollectors` it
  causes a bug "undefined method << for nil class"
- Move Puma's custom collector to the top level and autoload it
- Rename method `#custom_collectors!` to `#update_custom_collectors`