### PR TITLE
Exclude file version.rb from code coverage

### DIFF
--- a/spec/setup/simplecov.rb
+++ b/spec/setup/simplecov.rb
@@ -15,6 +15,7 @@ unless ENV.fetch('SIMPLECOV', '').empty?
 
   SimpleCov.start do
     add_filter '/spec/'
+    add_filter '/lib/bm/instrumentations/version.rb'
     track_files 'lib/**/*.rb'
   end
 end


### PR DESCRIPTION
Due to `simplecov` doesn't understand constants coverage, the version file always uncovered