### PR TITLE
Fix typo in `BM::Instrumentations::Aws.plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `BM::instruentations::Aws.plugin` argument `registry` have to be optional
+
 ## [1.0.0] - 2021-05-26
 
 ### Added

--- a/lib/bm/instrumentations/aws/collector.rb
+++ b/lib/bm/instrumentations/aws/collector.rb
@@ -16,7 +16,7 @@ module BM
       #
       # @param registry [Prometheus::Client::Registry, nil] overrides a default registry
       # @return [Collector]
-      def self.plugin(registry)
+      def self.plugin(registry = nil)
         metrics_collection = MetricsCollection.new(registry || Prometheus::Client.registry)
         Collector.new(metrics_collection)
       end


### PR DESCRIPTION
The parameter `registry` have to optional (as expected).