### PR TITLE
Add ability to override an application name in `endpoint` Roda plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ability to override an application name in `endpoint` Roda plugin, by default
+  it picks up from a `class.name`
+
 ## [1.0.0] - 2021-05-26
 
 ### Added

--- a/lib/roda/plugins/endpoint.rb
+++ b/lib/roda/plugins/endpoint.rb
@@ -25,8 +25,10 @@ class Roda
     #     end
     #   end
     module Endpoint
-      # @param app [Any]
-      def self.configure(app)
+      # @param app [Roda] the Roda application
+      # @param name [String] override the class name of the Roda application
+      def self.configure(app, name: nil)
+        app.opts[:endpoint_class_name] = name || app.name
         app.extend ClassMethods
       end
 
@@ -34,7 +36,7 @@ class Roda
       module ClassMethods
         # @param method_name [Symbol]
         def endpoint(method_name)
-          endpoint_name = "#{name}/#{method_name}"
+          endpoint_name = "#{opts[:endpoint_class_name]}/#{method_name}"
           prepend(Module.new do
             define_method(method_name) do |*args, **kwargs, &block|
               request.env[BM::Instrumentations::Rack::ENDPOINT] = endpoint_name

--- a/spec/roda/plugins/endpoint_spec.rb
+++ b/spec/roda/plugins/endpoint_spec.rb
@@ -57,4 +57,28 @@ RSpec.describe 'Roda::RodaPlugins::Endpoint', rack: true do
     expect(last_response.body).to eq('root')
     expect(last_response['X-Endpoint']).to eq('RodaAppTest/root')
   end
+
+  context 'with overridden application name' do
+    let(:api) do
+      Class.new(::Roda) do
+        plugin(:endpoint, name: 'OverriddenAppName')
+
+        def root
+          'root'
+        end
+        endpoint :root
+
+        route do |r|
+          r.root { root }
+        end
+      end
+    end
+
+    it 'sets endpoint name to Rack env' do
+      get '/'
+      expect(last_response).to be_ok
+      expect(last_response.body).to eq('root')
+      expect(last_response['X-Endpoint']).to eq('OverriddenAppName/root')
+    end
+  end
 end


### PR DESCRIPTION
For applications that active use namespaces the default path from a class
name is too long. For example `AudiobooksImport::Web::API::V2` could be
reduced to `API::V2`.